### PR TITLE
Add disableOnMobile props (default to false)

### DIFF
--- a/src/react-skrollr/ParallaxProvider.js
+++ b/src/react-skrollr/ParallaxProvider.js
@@ -5,11 +5,13 @@ import skrollr from 'skrollr'
 export default class ParallaxProvider extends React.Component {
   static propTypes = {
     init: PropTypes.object,
-    getScrollTop: PropTypes.func
+    getScrollTop: PropTypes.func,
+    disableOnMobile: PropTypes.bool
   }
 
   static defaultProps = {
     init: {},
+    disableOnMobile: true,
     getScrollTop: () => null
   }
 
@@ -18,10 +20,16 @@ export default class ParallaxProvider extends React.Component {
   }
 
   initSkrollr() {
+    
     this.skrollr = skrollr.init(this.props.init)
+    
     this.setState({
       refresh: this.skrollr.refresh
     })
+
+    if (disableOnMobile && this.skrollr.isMobile()) {
+      this.skrollr.destroy();
+    }
   }
 
   getScrollTop = () => {

--- a/src/react-skrollr/ParallaxProvider.js
+++ b/src/react-skrollr/ParallaxProvider.js
@@ -27,7 +27,7 @@ export default class ParallaxProvider extends React.Component {
       refresh: this.skrollr.refresh
     })
 
-    if (disableOnMobile && this.skrollr.isMobile()) {
+    if (this.props.disableOnMobile && this.skrollr.isMobile()) {
       this.skrollr.destroy();
     }
   }


### PR DESCRIPTION
Since Parallax is kinda buggy on mobile, user should use it as his/her own risk.
I suggest we disable this mobile option as a default.